### PR TITLE
fix(hostname): remove hostname from default

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -65,9 +65,9 @@ class smokeping::config {
     case $mode {
         ## Slave configuration
         'slave': {
-            if $smokeping::slave_display_name == '' { $display_name = $::hostname }
+            if $smokeping::slave_display_name == '' { $display_name = $::fqdn }
             if $smokeping::slave_color == '' { $slave_color = sprintf('%06d', fqdn_rand('999999')) }
-            smokeping::slave { $::hostname:
+            smokeping::slave { $::fqdn:
                 location     => $smokeping::slave_location,
                 display_name => $display_name,
                 color        => $slave_color,

--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -32,14 +32,14 @@ define smokeping::slave(
       group   => smokeping,
       content => $random_value,
   }
-  @@concat::fragment { "${::hostname}-secret":
+  @@concat::fragment { "${::fqdn}-secret":
       target  => $smokeping::slave_secrets,
       order   => 10,
       content => "${smokeping::slave_name}:${random_value}\n",
       tag     => "smokeping-slave-secret-${master}",
   }
 
-  $filename = "${smokeping::slave_dir}/${::hostname}"
+  $filename = "${smokeping::slave_dir}/${::fqdn}"
   @@file { $filename:
       content => template('smokeping/slave.erb'),
       tag     => "smokeping-slave-${master}",


### PR DESCRIPTION
Remove definition with hostname and use fqdn instead.
Reason : front01.toto and front01.tata have the same hostname
according to facter, resulting in puppet issue