### PR TITLE
Fixed error while using slave_display_name (was ignored)

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -65,11 +65,19 @@ class smokeping::config {
     case $mode {
         ## Slave configuration
         'slave': {
-            if $smokeping::slave_display_name == '' { $display_name = $::fqdn }
+
+            # Check if slave_display_name is unset.
+            # --> use FQDN if not set.
+            if $smokeping::slave_display_name == '' {
+                $display_name = $::fqdn
+            } else {
+                $display_name = $smokeping::slave_display_name
+            }
+
             if $smokeping::slave_color == '' { $slave_color = sprintf('%06d', fqdn_rand('999999')) }
             smokeping::slave { $::fqdn:
                 location     => $smokeping::slave_location,
-                display_name => $smokeping::display_name,
+                display_name => $display_name,
                 color        => $smokeping::slave_color,
             }
             # periodic restart to pick-up new config


### PR DESCRIPTION
Setting the display name using "slave_display_name" did not work here. The following fix solves this.