### PR TITLE
Small Improvements

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -103,7 +103,7 @@ class smokeping::config {
 
                 # collect shared secrets from slaves
                 concat { $smokeping::slave_secrets:
-                    owner => smokeping,
+                    owner => $daemon_user,
                     group => $webserver_group,
                     mode  => '0640',
                 }
@@ -113,7 +113,7 @@ class smokeping::config {
                 file {
                     $smokeping::slave_secrets:
                         ensure => present,
-                        owner  => smokeping,
+                        owner  => $daemon_user,
                         group  => $webserver_group,
                         mode   => '0640';
                 }

--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -28,8 +28,8 @@ define smokeping::slave(
   $random_value = fqdn_rand(1000000)
   file { $smokeping::shared_secret:
       mode    => '0600',
-      owner   => smokeping,
-      group   => smokeping,
+      owner   => $smokeping::daemon_user,
+      group   => $smokeping::daemon_group,
       content => $random_value,
   }
   @@concat::fragment { "${::fqdn}-secret":

--- a/manifests/target.pp
+++ b/manifests/target.pp
@@ -42,7 +42,7 @@ define smokeping::target (
     $remark = '',
     $options = {},
 ) {
-    validate_re( $name, '^[^[:space:]]+$', 'Target name cannot contain whitespace.' )
+    validate_re( $name, '^[-_0-9a-zA-Z]+$', 'There is a very limited syntax permitted for target names (/[-_0-9a-zA-Z]+/)')
     validate_string( $pagetitle )
     validate_string( $menu )
     validate_string( $hierarchy_parent )


### PR DESCRIPTION
Two small improvements:
1. Respect the configured user when setting file ownership. Makes it possible to change via param.
2. Validate the target names against ^[-_0-9a-zA-Z]+$ to catch any values that Smokeping won't accept - there's a lot more than just spaces unfortunately.