### PR TITLE
Allow to specify targets through hiera

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -32,6 +32,7 @@ class smokeping::config {
     $default_probe  = $smokeping::default_probe
     $cgi_remark_top = $smokeping::cgi_remark_top
     $cgi_title_top  = $smokeping::cgi_title_top
+    $targets        = $smokeping::targets
 
     # Pathnames
     $path_sendmail  = $smokeping::path_sendmail
@@ -136,6 +137,7 @@ class smokeping::config {
                 order   => 10,
                 content => template('smokeping/targets-header.erb'),
             }
+            create_resources("smokeping::target", $targets, {})
         }
         default: { fail("mode ${mode} unknown") }
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -76,6 +76,9 @@
 # [*targets_dir*]
 #   Where to save target definitions (Default: /etc/smokeping/config.d/targets.d)
 #
+# [*targets*]
+#   Target definitions as a Hash of Smokeping::Target (Default: {})
+#
 # [*daemon_user*]
 #   User to run SmokePing (Default: smokeping)
 #
@@ -153,6 +156,7 @@ class smokeping(
     $cgi_remark_top     = 'Welcome to the SmokePing website of xxx Company. Here you will learn all about the latency of our network.',
     $cgi_title_top      = 'Network Latency Grapher',
     $targets_dir        = '/etc/smokeping/config.d/targets.d',
+    $targets            = {},
     $daemon_user        = 'smokeping',
     $daemon_group       = 'smokeping',
     $path_sendmail      = '/usr/sbin/sendmail',


### PR DESCRIPTION
This can be done with something like that:

    smokeping::targets:
      World:
        menu: 'World'
        pagetitle: 'Connection to the World'
        alerts:
         - bigloss
         - noloss
      GoogleCH:
        hierarchy_parent: World
        hierarchy_level: 2
        menu: google.ch
        pagetitle: Google