### PR TITLE
perldoc namespace incorrect

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -7,8 +7,8 @@ class smokeping::install {
     if ! defined (Package['fping']) {
         package {'fping': ensure => installed; }
     }
-    if ! defined (Package[$smokeping::package_perldoc]) {
-        package {$smokeping::package_perldoc: ensure => installed; }
+    if ! defined (Package[$smokeping::params::package_perldoc]) {
+        package {$smokeping::params::package_perldoc: ensure => installed; }
     }
 
     # correct permissions


### PR DESCRIPTION
Hello! Our Puppet run was failing trying to install package `undef` for the perldoc package. It seems there is some confusion as to where parameters are coming from (some from init.pp others from params.pp), for now this fix unblocks us and anyone else trying the module.

Thanks for sharing the module.

PS: Greetings from @darktim 
