### PR TITLE
Include params needed

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,5 +1,6 @@
 class smokeping::install {
-
+    include smokeping::params
+    
     package { 'smokeping':
         ensure => $smokeping::version
     }


### PR DESCRIPTION
Well this is embarrasing... include params *is* needed for the perldoc package to be defined. This is what happens when you edit code directly in github. :disappointed: 