### PR TITLE
Only include /etc/smokeping/conf.d/Slaves when mode is master

### DIFF
--- a/templates/config.erb
+++ b/templates/config.erb
@@ -3,5 +3,7 @@
 @include /etc/smokeping/config.d/Database
 @include /etc/smokeping/config.d/Presentation
 @include /etc/smokeping/config.d/Probes
+<% if @mode == 'master' -%>
 @include /etc/smokeping/config.d/Slaves
+<% end -%>
 @include /etc/smokeping/config.d/Targets


### PR DESCRIPTION
Only include `/etc/smokeping/conf.d/Slaves` when mode is `master`, otherwise that file doesn't exist and smokeping dies with the error:
```
ERROR: can't open /etc/smokeping/config.d/Slaves: No such file or directory
```