### PR TITLE
Standardise variable name

### DIFF
--- a/templates/alerts.erb
+++ b/templates/alerts.erb
@@ -6,7 +6,7 @@ from=<%= @alerts_from %>
 
 <% @alerts.each do |alert| -%>
 + <%= alert['name'] %>
-type = <%= alert['alert_type'] %>
+type = <%= alert['type'] %>
 pattern = <%= alert['pattern'] %>
 comment = <%= alert['comment'] %>
 


### PR DESCRIPTION
Standardise variable name, so that the alert examples in `README` work as documented.

After applying this patch locally, my config worked:

```
Notice: /Stage[main]/Smokeping::Config/File[/etc/smokeping/config.d/Alerts]/content: 
--- /etc/smokeping/config.d/Alerts	2016-08-09 15:11:57.961237739 +0000
+++ /tmp/puppet-file20160815-3519-4fmnvu	2016-08-15 13:34:25.951451965 +0000
@@ -5,17 +5,17 @@
 # THIS FILE IS MANAGED BY PUPPET
 
 + bigloss
-type = 
+type = loss
 pattern = ==0%,==0%,==0%,==0%,>0%,>0%,>0%
 comment = suddenly there is packet loss
 
 + startloss
-type = 
+type = loss
 pattern = ==S,>0%,>0%,>0%
 comment = loss at startup
 
 + noloss
-type = 
+type = loss
 pattern = >0%,>0%,>0%,==0%,==0%,==0%,==0%
 comment = there was loss and now its reachable again
 

Info: Computing checksum on file /etc/smokeping/config.d/Alerts
Info: /Stage[main]/Smokeping::Config/File[/etc/smokeping/config.d/Alerts]: Filebucketed /etc/smokeping/config.d/Alerts to puppet with sum 07ca2d3164fbcc144de49d14711f9a38
Notice: /Stage[main]/Smokeping::Config/File[/etc/smokeping/config.d/Alerts]/content: content changed '{md5}07ca2d3164fbcc144de49d14711f9a38' to '{md5}5c0698ee1e6a0a82db3dd2090d9a7afe'
```