### PR TITLE
Fix param name

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,20 +75,20 @@ Class['::smokeping'] {
 ### Alerts
 ```puppet
 $alerts = [ {
-  { name    => 'bigloss',
-  type    => 'loss',
-  pattern => '==0%,==0%,==0%,==0%,>0%,>0%,>0%',
-  comment => 'suddenly there is packet loss' },
+  { name     => 'bigloss',
+  alert_type => 'loss',
+  pattern    => '==0%,==0%,==0%,==0%,>0%,>0%,>0%',
+  comment    => 'suddenly there is packet loss' },
 
-  { name    => 'startloss',
-  type    => 'loss',
-  pattern => '==S,>0%,>0%,>0%',
-  comment => 'loss at startup' },
+  { name     => 'startloss',
+  alert_type => 'loss',
+  pattern    => '==S,>0%,>0%,>0%',
+  comment    => 'loss at startup' },
 
-  { name    => 'noloss',
-  type    => 'loss',
-  pattern => '>0%,>0%,>0%,==0%,==0%,==0%,==0%',
-  comment => 'there was loss and now its reachable again' },
+  { name     => 'noloss',
+  alert_type => 'loss',
+  pattern    => '>0%,>0%,>0%,==0%,==0%,==0%,==0%',
+  comment    => 'there was loss and now its reachable again' },
 ] }
 Class['::smokeping'] {
   alerts => $alerts


### PR DESCRIPTION
Update `README` to match the code in 78dc09deecd0ec61c70e13c44eabcc448028a35c so the alert examples in the docs now work :smile: