### PR TITLE
Manage Apache

### DIFF
--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -3,7 +3,7 @@ class smokeping::apache {
   $servername = $::smokeping::servername
 
   $docroot = $::osfamily ? {
-    'RedHat' => '/usr/share/smokeping/htdocs',
+    'RedHat' => '/usr/share/smokeping/cgi',
     'Debian' => '/usr/share/smokeping/www',
   }
 

--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -61,10 +61,12 @@ class smokeping::apache {
 
   # Configure apache
   include ::apache
+  include ::apache::mod::perl
   apache::vhost { 'smokeping':
-    servername  => $servername,
-    docroot     => $docroot,
-    directories => $directories,
-    aliases     => $aliases,
+    servername     => $servername,
+    docroot        => $docroot,
+    directories    => $directories,
+    aliases        => $aliases,
+    directoryindex => 'smokeping.cgi',
   }
 }

--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -43,11 +43,11 @@ class smokeping::apache {
     'RedHat' => [
       {
         'path'    => '/usr/share/smokeping',
-        'require' => 'local',
+        'require' => 'all granted',
       },
       {
         'path'    => '/var/lib/smokeping',
-        'require' => 'local',
+        'require' => 'all granted',
       },
     ],
     'Debian' => [

--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -1,5 +1,6 @@
 # Manage Apache config
 class smokeping::apache {
+  $servername = $::smokeping::servername
 
   $docroot = $::osfamily ? {
     'RedHat' => '/usr/share/smokeping/htdocs',
@@ -61,7 +62,7 @@ class smokeping::apache {
   # Configure apache
   include ::apache
   apache::vhost { 'smokeping':
-    servername  => $::fqdn,
+    servername  => $servername,
     docroot     => $docroot,
     directories => $directories,
     aliases     => $aliases,

--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -3,7 +3,7 @@ class smokeping::apache {
   $servername = $::smokeping::servername
 
   $docroot = $::osfamily ? {
-    'RedHat' => '/usr/share/smokeping/cgi',
+    'RedHat' => '/usr/share/smokeping/htdocs',
     'Debian' => '/usr/share/smokeping/www',
   }
 
@@ -18,14 +18,14 @@ class smokeping::apache {
         'alias' => '/smokeping',
         'path'  => '/usr/share/smokeping/htdocs',
       },
-      {
-        'scriptalias' => '/smokeping/sm.cgi',
-        'path'        => '/usr/share/smokeping/cgi/smokeping.fcgi',
-      },
 #      {
-#        scriptalias => '/smokeping/sm.cgi',
-#        path        => '/usr/share/smokeping/cgi/smokeping_cgi',
+#        'scriptalias' => '/smokeping/sm.cgi',
+#        'path'        => '/usr/share/smokeping/cgi/smokeping.fcgi',
 #      },
+      {
+        scriptalias => '/smokeping/sm.cgi',
+        path        => '/usr/share/smokeping/cgi/smokeping_cgi',
+      },
     ],
     'Debian' => [
       {

--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -1,0 +1,69 @@
+# Manage Apache config
+class smokeping::apache {
+
+  $docroot = $::osfamily ? {
+    'RedHat' => '/usr/share/smokeping/htdocs',
+    'Debian' => '/usr/share/smokeping/www',
+  }
+
+  # Construct hash of parameters
+  $aliases = $::osfamily ? {
+    'RedHat' => [
+      {
+        'alias' => '/smokeping/images',
+        'path'  => '/var/lib/smokeping/images',
+      },
+      {
+        'alias' => '/smokeping',
+        'path'  => '/usr/share/smokeping/htdocs',
+      },
+      {
+        'scriptalias' => '/smokeping/sm.cgi',
+        'path'        => '/usr/share/smokeping/cgi/smokeping.fcgi',
+      },
+#      {
+#        scriptalias => '/smokeping/sm.cgi',
+#        path        => '/usr/share/smokeping/cgi/smokeping_cgi',
+#      },
+    ],
+    'Debian' => [
+      {
+        'alias' => '/smokeping',
+        'path'  => '/usr/share/smokeping/www',
+      },
+      {
+        'scriptalias' => '/smokeping/smokeping.cgi',
+        'path'        => '/usr/lib/cgi-bin/smokeping.cgi',
+      },
+    ],
+  }
+
+
+  $directories = $::osfamily ? {
+    'RedHat' => [
+      {
+        'path'    => '/usr/share/smokeping',
+        'require' => 'local',
+      },
+      {
+        'path'    => '/var/lib/smokeping',
+        'require' => 'local',
+      },
+    ],
+    'Debian' => [
+      {
+        'path'    => '/usr/share/smokeping/www',
+        'options' => '+FollowSymLinks',
+      },
+    ],
+  }
+
+  # Configure apache
+  include ::apache
+  apache::vhost { 'smokeping':
+    servername  => $::fqdn,
+    docroot     => $docroot,
+    directories => $directories,
+    aliases     => $aliases,
+  }
+}

--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -26,6 +26,14 @@ class smokeping::apache {
         scriptalias => '/smokeping/sm.cgi',
         path        => '/usr/share/smokeping/cgi/smokeping_cgi',
       },
+      {
+        scriptalias => '/smokeping/smokeping.cgi',
+        path        => '/usr/share/smokeping/cgi/smokeping_cgi',
+      },
+      {
+        scriptalias => '/smokeping.cgi',
+        path        => '/usr/share/smokeping/cgi/smokeping_cgi',
+      },
     ],
     'Debian' => [
       {
@@ -43,8 +51,10 @@ class smokeping::apache {
   $directories = $::osfamily ? {
     'RedHat' => [
       {
-        'path'    => '/usr/share/smokeping',
-        'require' => 'all granted',
+        'path'     => '/usr/share/smokeping/htdocs',
+        'require'  => 'all granted',
+        'options'  => '+FollowSymLinks +Indexes',
+        'override' => 'All',
       },
       {
         'path'    => '/var/lib/smokeping',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -171,6 +171,7 @@ class smokeping(
     $start              = true,
     $manage_apache      = false,
     $manage_firewall    = false,
+    $servername         = $::fqdn,
 ) {
 
     if $manage_apache {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -170,10 +170,24 @@ class smokeping(
     $enable             = true,
     $start              = true,
     $manage_apache      = false,
+    $manage_firewall    = false,
 ) {
 
     if $manage_apache {
       include ::smokeping::apache
+    }
+
+    if $manage_firewall {
+      firewall { '100-smokeping-http':
+        proto  => 'tcp',
+        dport  => '80',
+        action => 'accept',
+      }
+      firewall { '100-smokeping-https':
+        proto  => 'tcp',
+        dport  => '443',
+        action => 'accept',
+      }
     }
 
     class{'smokeping::install': } ->

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -169,7 +169,13 @@ class smokeping(
     $version            = 'present',
     $enable             = true,
     $start              = true,
+    $manage_apache      = false,
 ) {
+
+    if $manage_apache {
+      include ::smokeping::apache
+    }
+
     class{'smokeping::install': } ->
     class{'smokeping::config': } ~>
     class{'smokeping::service': } ->

--- a/metadata.json
+++ b/metadata.json
@@ -17,6 +17,7 @@
   "dependencies": [
     { "name": "puppetlabs/stdlib", "version_requirement": ">=3.2.0 <5.0.0" },
     { "name": "puppetlabs/concat", "version_requirement": ">= 1.0.0" },
-    { "name": "puppetlabs/apache", "version_requirement": ">= 1.0.0" }
+    { "name": "puppetlabs/apache", "version_requirement": ">= 1.0.0" },
+    { "name": "puppetlabs/firewall", "version_requirement": ">= 1.0.0" }
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -16,6 +16,7 @@
   ],
   "dependencies": [
     { "name": "puppetlabs/stdlib", "version_requirement": ">=3.2.0 <5.0.0" },
-    { "name": "puppetlabs/concat", "version_requirement": ">= 1.0.0" }
+    { "name": "puppetlabs/concat", "version_requirement": ">= 1.0.0" },
+    { "name": "puppetlabs/apache", "version_requirement": ">= 1.0.0" }
   ]
 }


### PR DESCRIPTION
Improvement to the original module by using [`puppetlabs/apache`](https://forge.puppet.com/puppetlabs/apache) and [`puppetlabs/firewall`](https://forge.puppet.com/puppetlabs/firewall) to manage the Apache web config and firewall rules respectively. These are controlled by boolean params which default to `false` to retain the original behaviour of this module.