### PR TITLE
Add support to manage an SELinux policy

### DIFF
--- a/files/local_smokeping.te
+++ b/files/local_smokeping.te
@@ -1,0 +1,20 @@
+module local_smokeping 1.4;
+
+require {
+	type httpd_t;
+	type smokeping_cgi_script_t;
+	type smokeping_var_lib_t;
+	type var_lib_t;
+
+	class dir { add_name read write };
+	class file { create getattr ioctl open read write };
+	class process { noatsecure rlimitinh siginh };
+}
+
+#============= httpd_t ==============
+allow httpd_t smokeping_cgi_script_t:process { noatsecure rlimitinh siginh };
+allow httpd_t smokeping_var_lib_t:dir { read };
+
+#============= smokeping_cgi_script_t ==============
+allow smokeping_cgi_script_t var_lib_t:dir { add_name read write };
+allow smokeping_cgi_script_t var_lib_t:file { create getattr ioctl open read write };

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -120,6 +120,14 @@
 #
 # [*start*]
 #   Should the service be started by Puppet? (Default: true)
+# [*smanage_apache*]
+#   Should we manage the Apache config with puppetlabs/apache? (Default: false)
+#
+# [*smanage_firewall*]
+#   Should we manage a firewall rule for Smokeping with puppetlabs/firewall? (Default: false)
+#
+# [*smanage_selinux*]
+#   Should we load an SELinux policy to allow Smokeping to work on Red Hat distros? (Default: false)
 #
 # === Author
 #
@@ -171,6 +179,7 @@ class smokeping(
     $start              = true,
     $manage_apache      = false,
     $manage_firewall    = false,
+    $manage_selinux     = false,
     $servername         = $::fqdn,
 ) {
 
@@ -188,6 +197,15 @@ class smokeping(
         proto  => 'tcp',
         dport  => '443',
         action => 'accept',
+      }
+    }
+
+    if $manage_selinux {
+      if $::osfamily == 'RedHat' {
+        selinux::module { 'local_smokeping':
+          ensure => 'present',
+          source => 'puppet:///modules/smokeping/local_smokeping.te',
+        }
       }
     }
 

--- a/metadata.json
+++ b/metadata.json
@@ -18,6 +18,7 @@
     { "name": "puppetlabs/stdlib", "version_requirement": ">=3.2.0 <5.0.0" },
     { "name": "puppetlabs/concat", "version_requirement": ">= 1.0.0" },
     { "name": "puppetlabs/apache", "version_requirement": ">= 1.0.0" },
-    { "name": "puppetlabs/firewall", "version_requirement": ">= 1.0.0" }
+    { "name": "puppetlabs/firewall", "version_requirement": ">= 1.0.0" },
+    { "name": "jfryman/selinux", "version_requirement": ">= 0.4.0" }
   ]
 }


### PR DESCRIPTION
Add support to manage an SELinux policy which enables Smokeping to work properly on Red Hat. The new parameter defaults to `false` to retain original behaviour