### PR TITLE
Concat resources need to depend on target dir

### DIFF
--- a/manifests/target.pp
+++ b/manifests/target.pp
@@ -56,10 +56,11 @@ define smokeping::target (
 
     $filename = "${smokeping::targets_dir}/${hierarchy_level}-${name}"
     concat { $filename:
-        owner  => root,
-        group  => root,
-        mode   => '0644',
-        notify => Class['smokeping::service'],
+        owner   => root,
+        group   => root,
+        mode    => '0644',
+        require => File[$::smokeping::targets_dir],
+        notify  => Class['smokeping::service'],
     }
     concat::fragment { "target-definition-${hierarchy_level}-${name}":
         target  => $filename,


### PR DESCRIPTION
With puppet-concat < 2.x, the underlying implementation used lots of
file resources.  That had the side effect that those resources would
automatically depend on the target directory.  However, with 2.x and
later, the concat resources are implemented as a native type, so we need
to add an explicit dependency on the target dir as a result.